### PR TITLE
Fix CMake CMP0167 policy warning by using CONFIG mode for find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Search for Boost: headers are required and the other components are needed for the binaries.
-find_package(Boost ${BOOST_MIN_VERSION} REQUIRED OPTIONAL_COMPONENTS iostreams program_options serialization)
+find_package(Boost ${BOOST_MIN_VERSION} CONFIG REQUIRED OPTIONAL_COMPONENTS iostreams program_options serialization)
 if(Boost_IOSTREAMS_FOUND)
    set(PAPILO_HAVE_BOOST_IOSTREAMS 1)
 else()

--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -85,7 +85,7 @@ if(TARGET clusol)
 endif()
 
 # Search again since we cannot rely on papilo/CMakeLists.txt having searched for Boost already.
-find_package(Boost ${BOOST_MIN_VERSION} OPTIONAL_COMPONENTS iostreams program_options serialization)
+find_package(Boost ${BOOST_MIN_VERSION} CONFIG OPTIONAL_COMPONENTS iostreams program_options serialization)
 
 include_directories(${SCIP_INCLUDE_DIRS} ${SOPLEX_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED OPTIONAL_COMPONENTS serialization program_options iostreams)
+find_package(Boost CONFIG REQUIRED OPTIONAL_COMPONENTS serialization program_options iostreams)
 
 if (TARGET papilolib)
     set(PAPILOLIB_TESTS


### PR DESCRIPTION
- Add CONFIG keyword to all find_package(Boost) calls to use Boost's official BoostConfig.cmake instead of deprecated FindBoost module
- This resolves CMP0167 policy warnings in CMake 3.30+
- Updated files:
  - CMakeLists.txt (main)
  - binaries/CMakeLists.txt
  - test/CMakeLists.txt

The CONFIG mode ensures compatibility with modern CMake versions while maintaining backward compatibility.