### PR TITLE
Add CMake presets configuration and update GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,10 @@ jobs:
           sudo apt-get install -y cmake ninja-build libtbb-dev libboost-dev
 
       - name: Configure CMake
-        run: |
-          cmake -B ${{ github.workspace }}/build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+        run: cmake --preset debug
 
       - name: Build
-        run: cmake --build ${{ github.workspace }}/build
+        run: cmake --build --preset debug
 
       - name: Test
-        working-directory: ${{ github.workspace }}/build
-        run: ctest --output-on-failure
+        run: ctest --preset debug

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,10 +1,5 @@
 {
   "version": 3,
-  "cmakeMinimumRequired": {
-    "major": 3,
-    "minor": 20,
-    "patch": 0
-  },
   "configurePresets": [
     {
       "name": "default",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,58 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "description": "Default build configuration",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "GMP": "OFF",
+        "QUADMATH": "OFF"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug Config",
+      "description": "Debug build configuration",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Introduce CMake presets for build configurations, set Ninja as the default generator, and separate build directories for release and debug. Update the GitHub Actions workflow to utilize these presets for configuration, building, and testing. Disable GMP and QUADMATH support in the process.