### PR TITLE
Improve const correctness in libpapilo C API

### DIFF
--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -101,7 +101,7 @@ struct libpapilo_problem_update_t
                                PostsolveStorage<double>& postsolve,
                                Statistics& stats,
                                const PresolveOptions& options,
-                               const Num<double>& num, Message& msg )
+                               const Num<double>& num, const Message& msg )
        : update( problem, postsolve, stats, options, num, msg )
    {
    }
@@ -1576,9 +1576,9 @@ extern "C"
    libpapilo_problem_update_create( libpapilo_problem_t* problem,
                                     libpapilo_postsolve_storage_t* postsolve,
                                     libpapilo_statistics_t* statistics,
-                                    libpapilo_presolve_options_t* options,
-                                    libpapilo_num_t* num,
-                                    libpapilo_message_t* message )
+                                    const libpapilo_presolve_options_t* options,
+                                    const libpapilo_num_t* num,
+                                    const libpapilo_message_t* message )
    {
       check_problem_ptr( problem );
       check_postsolve_storage_ptr( postsolve );

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1446,9 +1446,9 @@ extern "C"
    /* PostsolveStorage management implementation */
 
    libpapilo_postsolve_storage_t*
-   libpapilo_postsolve_storage_create( const libpapilo_problem_t* problem,
-                                       const libpapilo_num_t* num,
-                                       const libpapilo_presolve_options_t* options )
+   libpapilo_postsolve_storage_create(
+       const libpapilo_problem_t* problem, const libpapilo_num_t* num,
+       const libpapilo_presolve_options_t* options )
    {
       check_problem_ptr( problem );
       check_num_ptr( num );
@@ -1699,7 +1699,8 @@ extern "C"
                                      const libpapilo_problem_update_t* update,
                                      const libpapilo_num_t* num,
                                      libpapilo_reductions_t* reductions,
-                                     const libpapilo_timer_t* timer, int* cause )
+                                     const libpapilo_timer_t* timer,
+                                     int* cause )
    {
       check_singleton_cols_ptr( presolver );
       check_problem_ptr( problem );
@@ -1739,7 +1740,8 @@ extern "C"
 
    libpapilo_presolve_status_t
    libpapilo_simple_substitution_execute(
-       libpapilo_simple_substitution_t* presolver, const libpapilo_problem_t* problem,
+       libpapilo_simple_substitution_t* presolver,
+       const libpapilo_problem_t* problem,
        const libpapilo_problem_update_t* update, const libpapilo_num_t* num,
        libpapilo_reductions_t* reductions, const libpapilo_timer_t* timer,
        int* cause )

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1446,9 +1446,9 @@ extern "C"
    /* PostsolveStorage management implementation */
 
    libpapilo_postsolve_storage_t*
-   libpapilo_postsolve_storage_create( libpapilo_problem_t* problem,
-                                       libpapilo_num_t* num,
-                                       libpapilo_presolve_options_t* options )
+   libpapilo_postsolve_storage_create( const libpapilo_problem_t* problem,
+                                       const libpapilo_num_t* num,
+                                       const libpapilo_presolve_options_t* options )
    {
       check_problem_ptr( problem );
       check_num_ptr( num );
@@ -1695,11 +1695,11 @@ extern "C"
 
    libpapilo_presolve_status_t
    libpapilo_singleton_cols_execute( libpapilo_singleton_cols_t* presolver,
-                                     libpapilo_problem_t* problem,
-                                     libpapilo_problem_update_t* update,
-                                     libpapilo_num_t* num,
+                                     const libpapilo_problem_t* problem,
+                                     const libpapilo_problem_update_t* update,
+                                     const libpapilo_num_t* num,
                                      libpapilo_reductions_t* reductions,
-                                     libpapilo_timer_t* timer, int* cause )
+                                     const libpapilo_timer_t* timer, int* cause )
    {
       check_singleton_cols_ptr( presolver );
       check_problem_ptr( problem );
@@ -1739,9 +1739,9 @@ extern "C"
 
    libpapilo_presolve_status_t
    libpapilo_simple_substitution_execute(
-       libpapilo_simple_substitution_t* presolver, libpapilo_problem_t* problem,
-       libpapilo_problem_update_t* update, libpapilo_num_t* num,
-       libpapilo_reductions_t* reductions, libpapilo_timer_t* timer,
+       libpapilo_simple_substitution_t* presolver, const libpapilo_problem_t* problem,
+       const libpapilo_problem_update_t* update, const libpapilo_num_t* num,
+       libpapilo_reductions_t* reductions, const libpapilo_timer_t* timer,
        int* cause )
    {
       check_simple_substitution_ptr( presolver );
@@ -1810,8 +1810,8 @@ extern "C"
    /* Postsolve Engine API Implementation */
 
    libpapilo_postsolve_t*
-   libpapilo_postsolve_create( libpapilo_message_t* message,
-                               libpapilo_num_t* num )
+   libpapilo_postsolve_create( const libpapilo_message_t* message,
+                               const libpapilo_num_t* num )
    {
       check_message_ptr( message );
       check_num_ptr( num );

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -522,9 +522,9 @@ extern "C"
 
    /* PostsolveStorage management */
    LIBPAPILO_EXPORT libpapilo_postsolve_storage_t*
-   libpapilo_postsolve_storage_create( const libpapilo_problem_t* problem,
-                                       const libpapilo_num_t* num,
-                                       const libpapilo_presolve_options_t* options );
+   libpapilo_postsolve_storage_create(
+       const libpapilo_problem_t* problem, const libpapilo_num_t* num,
+       const libpapilo_presolve_options_t* options );
 
    LIBPAPILO_EXPORT void
    libpapilo_postsolve_storage_free( libpapilo_postsolve_storage_t* postsolve );
@@ -614,7 +614,8 @@ extern "C"
                                      const libpapilo_problem_update_t* update,
                                      const libpapilo_num_t* num,
                                      libpapilo_reductions_t* reductions,
-                                     const libpapilo_timer_t* timer, int* cause );
+                                     const libpapilo_timer_t* timer,
+                                     int* cause );
 
    /* SimpleSubstitution Presolver API */
    LIBPAPILO_EXPORT libpapilo_simple_substitution_t*
@@ -626,7 +627,8 @@ extern "C"
 
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_simple_substitution_execute(
-       libpapilo_simple_substitution_t* presolver, const libpapilo_problem_t* problem,
+       libpapilo_simple_substitution_t* presolver,
+       const libpapilo_problem_t* problem,
        const libpapilo_problem_update_t* update, const libpapilo_num_t* num,
        libpapilo_reductions_t* reductions, const libpapilo_timer_t* timer,
        int* cause );

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -574,9 +574,9 @@ extern "C"
    libpapilo_problem_update_create( libpapilo_problem_t* problem,
                                     libpapilo_postsolve_storage_t* postsolve,
                                     libpapilo_statistics_t* statistics,
-                                    libpapilo_presolve_options_t* options,
-                                    libpapilo_num_t* num,
-                                    libpapilo_message_t* message );
+                                    const libpapilo_presolve_options_t* options,
+                                    const libpapilo_num_t* num,
+                                    const libpapilo_message_t* message );
 
    LIBPAPILO_EXPORT void
    libpapilo_problem_update_free( libpapilo_problem_update_t* update );

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -522,9 +522,9 @@ extern "C"
 
    /* PostsolveStorage management */
    LIBPAPILO_EXPORT libpapilo_postsolve_storage_t*
-   libpapilo_postsolve_storage_create( libpapilo_problem_t* problem,
-                                       libpapilo_num_t* num,
-                                       libpapilo_presolve_options_t* options );
+   libpapilo_postsolve_storage_create( const libpapilo_problem_t* problem,
+                                       const libpapilo_num_t* num,
+                                       const libpapilo_presolve_options_t* options );
 
    LIBPAPILO_EXPORT void
    libpapilo_postsolve_storage_free( libpapilo_postsolve_storage_t* postsolve );
@@ -610,11 +610,11 @@ extern "C"
 
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_singleton_cols_execute( libpapilo_singleton_cols_t* presolver,
-                                     libpapilo_problem_t* problem,
-                                     libpapilo_problem_update_t* update,
-                                     libpapilo_num_t* num,
+                                     const libpapilo_problem_t* problem,
+                                     const libpapilo_problem_update_t* update,
+                                     const libpapilo_num_t* num,
                                      libpapilo_reductions_t* reductions,
-                                     libpapilo_timer_t* timer, int* cause );
+                                     const libpapilo_timer_t* timer, int* cause );
 
    /* SimpleSubstitution Presolver API */
    LIBPAPILO_EXPORT libpapilo_simple_substitution_t*
@@ -626,9 +626,9 @@ extern "C"
 
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_simple_substitution_execute(
-       libpapilo_simple_substitution_t* presolver, libpapilo_problem_t* problem,
-       libpapilo_problem_update_t* update, libpapilo_num_t* num,
-       libpapilo_reductions_t* reductions, libpapilo_timer_t* timer,
+       libpapilo_simple_substitution_t* presolver, const libpapilo_problem_t* problem,
+       const libpapilo_problem_update_t* update, const libpapilo_num_t* num,
+       libpapilo_reductions_t* reductions, const libpapilo_timer_t* timer,
        int* cause );
 
    /* Solution Management API */
@@ -648,8 +648,8 @@ extern "C"
 
    /* Postsolve Engine API */
    LIBPAPILO_EXPORT libpapilo_postsolve_t*
-   libpapilo_postsolve_create( libpapilo_message_t* message,
-                               libpapilo_num_t* num );
+   libpapilo_postsolve_create( const libpapilo_message_t* message,
+                               const libpapilo_num_t* num );
 
    LIBPAPILO_EXPORT void
    libpapilo_postsolve_free( libpapilo_postsolve_t* postsolve );


### PR DESCRIPTION
## Summary

This PR improves const correctness throughout the libpapilo C API by adding `const` qualifiers to function parameters that are only read, not modified.

## Changes

### Functions updated with const parameters:

1. **`libpapilo_problem_update_create`**
   - `const libpapilo_presolve_options_t* options`
   - `const libpapilo_num_t* num`  
   - `const libpapilo_message_t* message`

2. **`libpapilo_postsolve_storage_create`**
   - `const libpapilo_problem_t* problem`
   - `const libpapilo_num_t* num`
   - `const libpapilo_presolve_options_t* options`

3. **`libpapilo_postsolve_create`**
   - `const libpapilo_message_t* message`
   - `const libpapilo_num_t* num`

4. **`libpapilo_singleton_cols_execute`**
   - `const libpapilo_problem_t* problem`
   - `const libpapilo_problem_update_t* update`
   - `const libpapilo_num_t* num`
   - `const libpapilo_timer_t* timer`

5. **`libpapilo_simple_substitution_execute`**
   - `const libpapilo_problem_t* problem`
   - `const libpapilo_problem_update_t* update`
   - `const libpapilo_num_t* num`
   - `const libpapilo_timer_t* timer`

### Parameters intentionally kept mutable:

- `libpapilo_reductions_t* reductions` in execute functions - The C++ implementation modifies the reductions object during execution
- `int* cause` in execute functions - Output parameter for error reasons
- `double* time_ref` in `libpapilo_timer_create` - Timer accumulates time into this reference

## Rationale

These changes align the C API with the underlying C++ implementations, which accept const references for read-only parameters. This improves:
- API clarity by making parameter intent explicit
- Potential compiler optimizations
- Prevention of accidental modifications

All tests pass with these changes.