### PR TITLE
Bump version to 2.4.3-jij.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(PAPILO_VERSION_MINOR 4)
 set(PAPILO_VERSION_PATCH 3)
 
 # Jij-specific patch version for libpapilo packaging
-set(LIBPAPILO_JIJ_PATCH_VERSION 3)
+set(LIBPAPILO_JIJ_PATCH_VERSION 4)
 set(PAPILO_API_VERSION 3)
 
 # Full version string including Jij patch version


### PR DESCRIPTION
Update the Jij-specific patch version for libpapilo to reflect the new release.