### PR TITLE
C API: Enforce Message requirement for Presolve

### DIFF
--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1206,9 +1206,14 @@ extern "C"
    /* Core Presolve API Implementation */
 
    libpapilo_presolve_t*
-   libpapilo_presolve_create()
+   libpapilo_presolve_create( const libpapilo_message_t* message )
    {
-      return check_run( []() { return new libpapilo_presolve_t(); },
+      check_message_ptr( message );
+      return check_run( [&]() {
+                           auto* p = new libpapilo_presolve_t();
+                           p->presolve.message() = message->message;
+                           return p;
+                        },
                         "Failed to create presolve object" );
    }
 
@@ -1233,15 +1238,6 @@ extern "C"
       check_presolve_ptr( presolve );
       check_presolve_options_ptr( options );
       presolve->presolve.getPresolveOptions() = options->options;
-   }
-
-   void
-   libpapilo_presolve_set_message( libpapilo_presolve_t* presolve,
-                                   const libpapilo_message_t* message )
-   {
-      check_presolve_ptr( presolve );
-      check_message_ptr( message );
-      presolve->presolve.message() = message->message;
    }
 
    
@@ -1291,12 +1287,14 @@ extern "C"
    libpapilo_presolve_status_t
    libpapilo_presolve_apply( libpapilo_problem_t* problem,
                              libpapilo_presolve_options_t* options,
+                             const libpapilo_message_t* message,
                              libpapilo_reductions_t** reductions_out,
                              libpapilo_postsolve_storage_t** postsolve_out,
                              libpapilo_statistics_t** statistics_out )
    {
       check_problem_ptr( problem );
       check_presolve_options_ptr( options );
+      check_message_ptr( message );
       custom_assert( reductions_out != nullptr,
                      "reductions_out pointer is null" );
       custom_assert( postsolve_out != nullptr,
@@ -1308,7 +1306,7 @@ extern "C"
           [&]()
           {
              // Create presolve object
-             auto* presolve = libpapilo_presolve_create();
+             auto* presolve = libpapilo_presolve_create( message );
              libpapilo_presolve_add_default_presolvers( presolve );
              libpapilo_presolve_set_options( presolve, options );
 

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1235,6 +1235,17 @@ extern "C"
       presolve->presolve.getPresolveOptions() = options->options;
    }
 
+   void
+   libpapilo_presolve_set_message( libpapilo_presolve_t* presolve,
+                                   const libpapilo_message_t* message )
+   {
+      check_presolve_ptr( presolve );
+      check_message_ptr( message );
+      presolve->presolve.message() = message->message;
+   }
+
+   
+
    libpapilo_presolve_status_t
    libpapilo_presolve_apply_simple( libpapilo_presolve_t* presolve,
                                     libpapilo_problem_t* problem )

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -433,7 +433,7 @@ extern "C"
 
    /* Core Presolve API */
    LIBPAPILO_EXPORT libpapilo_presolve_t*
-   libpapilo_presolve_create();
+   libpapilo_presolve_create( const libpapilo_message_t* message );
 
    LIBPAPILO_EXPORT void
    libpapilo_presolve_free( libpapilo_presolve_t* presolve );
@@ -473,6 +473,7 @@ extern "C"
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_presolve_apply( libpapilo_problem_t* problem,
                              libpapilo_presolve_options_t* options,
+                             const libpapilo_message_t* message,
                              libpapilo_reductions_t** reductions,
                              libpapilo_postsolve_storage_t** postsolve,
                              libpapilo_statistics_t** statistics );
@@ -592,12 +593,7 @@ extern "C"
    libpapilo_message_print( libpapilo_message_t* message, int level,
                             const char* text );
 
-   /* Presolve Message control API */
-   /* Copy the given Message into Presolve's internal Message */
-   LIBPAPILO_EXPORT void
-   libpapilo_presolve_set_message( libpapilo_presolve_t* presolve,
-                                   const libpapilo_message_t* message );
-
+   /* Presolve Message control: Presolve uses Message passed at create */
 
    /* ProblemUpdate Control API */
    LIBPAPILO_EXPORT libpapilo_problem_update_t*

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -445,6 +445,8 @@ extern "C"
    libpapilo_presolve_set_options( libpapilo_presolve_t* presolve,
                                    libpapilo_presolve_options_t* options );
 
+   
+
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_presolve_apply_simple( libpapilo_presolve_t* presolve,
                                     libpapilo_problem_t* problem );
@@ -589,6 +591,13 @@ extern "C"
    LIBPAPILO_EXPORT void
    libpapilo_message_print( libpapilo_message_t* message, int level,
                             const char* text );
+
+   /* Presolve Message control API */
+   /* Copy the given Message into Presolve's internal Message */
+   LIBPAPILO_EXPORT void
+   libpapilo_presolve_set_message( libpapilo_presolve_t* presolve,
+                                   const libpapilo_message_t* message );
+
 
    /* ProblemUpdate Control API */
    LIBPAPILO_EXPORT libpapilo_problem_update_t*

--- a/test/libpapilo/PresolveTest.cpp
+++ b/test/libpapilo/PresolveTest.cpp
@@ -108,7 +108,7 @@ applyReductions( libpapilo_problem_t* problem,
        update, postpone_substitutions ? 1 : 0 );
 
    // Apply reductions using presolve
-   libpapilo_presolve_t* presolve = libpapilo_presolve_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
    libpapilo_presolve_add_default_presolvers( presolve );
 
    int num_rounds = 0;


### PR DESCRIPTION
Require a Message during the creation of Presolve objects and during high-level apply operations. Remove outdated APIs related to message configuration, streamlining the interface for better consistency and clarity. Adjust tests to ensure compliance with the new requirements.