### PR TITLE
Add local installation preset and task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ cmake-build-debug/
 cmake-build-debug-coverage/
 external/tbb/cmake/
 solutions.test
+local_install/
 
 #downloads
 cmake/*tgz

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,16 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
+    },
+    {
+      "name": "local-install",
+      "displayName": "Local Install Config",
+      "description": "Build configuration with local installation",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build/local-install",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/local_install"
+      }
     }
   ],
   "buildPresets": [
@@ -32,6 +42,10 @@
     {
       "name": "debug",
       "configurePreset": "debug"
+    },
+    {
+      "name": "local-install",
+      "configurePreset": "local-install"
     }
   ],
   "testPresets": [

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,3 +23,10 @@ tasks:
     cmds:
       - cmake --build --preset debug --target libpapilo_unit_test
       - ctest --preset debug --tests-regex libpapilo
+
+  local-install:
+    desc: Build and install to local_install directory
+    cmds:
+      - cmake --preset local-install
+      - cmake --build --preset local-install
+      - cmake --install build/local-install


### PR DESCRIPTION
Introduce a CMake preset for local installation to the `local_install` directory and add a corresponding task for streamlined build and install processes. Update `.gitignore` to exclude the `local_install` directory.