### PR TITLE
Set threads and random seed in presolve options

### DIFF
--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1220,6 +1220,22 @@ extern "C"
       options->options.dualreds = dualreds;
    }
 
+   void
+   libpapilo_presolve_options_set_threads(
+       libpapilo_presolve_options_t* options, int threads )
+   {
+      check_presolve_options_ptr( options );
+      options->options.threads = threads;
+   }
+
+   void
+   libpapilo_presolve_options_set_randomseed(
+       libpapilo_presolve_options_t* options, unsigned int randomseed )
+   {
+      check_presolve_options_ptr( options );
+      options->options.randomseed = randomseed;
+   }
+
    /* Core Presolve API Implementation */
 
    libpapilo_presolve_t*

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -539,6 +539,14 @@ extern "C"
    libpapilo_presolve_options_set_dualreds(
        libpapilo_presolve_options_t* options, int dualreds );
 
+   LIBPAPILO_EXPORT void
+   libpapilo_presolve_options_set_threads(
+       libpapilo_presolve_options_t* options, int threads );
+
+   LIBPAPILO_EXPORT void
+   libpapilo_presolve_options_set_randomseed(
+       libpapilo_presolve_options_t* options, unsigned int randomseed );
+
    /* Main presolve function */
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_presolve_apply( libpapilo_problem_t* problem,


### PR DESCRIPTION
Add functions to set the number of threads and the random seed in the presolve options, enhancing configurability.