### PR TITLE
Add parameter setting API and simplify presolve apply functions

### DIFF
--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1406,23 +1406,6 @@ extern "C"
    }
 
    libpapilo_presolve_status_t
-   libpapilo_presolve_apply_simple( libpapilo_presolve_t* presolve,
-                                    libpapilo_problem_t* problem )
-   {
-      check_presolve_ptr( presolve );
-      check_problem_ptr( problem );
-
-      return check_run(
-          [&]()
-          {
-             PresolveResult<double> result =
-                 presolve->presolve.apply( problem->problem );
-             return convert_presolve_status( result.status );
-          },
-          "Failed to apply presolve" );
-   }
-
-   libpapilo_presolve_status_t
    libpapilo_presolve_apply_full( libpapilo_presolve_t* presolve,
                                   libpapilo_problem_t* problem,
                                   libpapilo_postsolve_storage_t** postsolve_out,
@@ -1500,80 +1483,6 @@ extern "C"
              *num_changes = result.second;
           },
           "Failed to apply reductions" );
-   }
-
-   /* High-level presolve function for backward compatibility */
-   libpapilo_presolve_status_t
-   libpapilo_presolve_apply( libpapilo_problem_t* problem,
-                             const libpapilo_presolve_options_t* options,
-                             const libpapilo_message_t* message,
-                             libpapilo_reductions_t** reductions_out,
-                             libpapilo_postsolve_storage_t** postsolve_out,
-                             libpapilo_statistics_t** statistics_out )
-   {
-      check_problem_ptr( problem );
-      check_presolve_options_ptr( options );
-      check_message_ptr( message );
-      custom_assert( reductions_out != nullptr,
-                     "reductions_out pointer is null" );
-      custom_assert( postsolve_out != nullptr,
-                     "postsolve_out pointer is null" );
-      custom_assert( statistics_out != nullptr,
-                     "statistics_out pointer is null" );
-
-      return check_run(
-          [&]()
-          {
-             // Create presolve object
-             auto* presolve = libpapilo_presolve_create( message );
-             libpapilo_presolve_add_default_presolvers( presolve );
-             libpapilo_presolve_set_options( presolve, options );
-
-             // Execute presolve
-             PresolveResult<double> result =
-                 presolve->presolve.apply( problem->problem );
-
-             // Create output objects
-             auto* postsolve_storage = new libpapilo_postsolve_storage_t(
-                 std::move( result.postsolve ) );
-             auto* reductions = new libpapilo_reductions_t();
-             auto* stats = new libpapilo_statistics_t();
-
-             // Copy overall statistics
-             stats->statistics = presolve->presolve.getStatistics();
-
-             // Copy per-presolver statistics
-             stats->presolver_stats.clear();
-             const auto& presolvers = presolve->presolve.getPresolvers();
-             const auto& presolverStats =
-                 presolve->presolve.getPresolverStats();
-
-             size_t numPresolvers =
-                 std::min( presolvers.size(), presolverStats.size() );
-             for( size_t i = 0; i < numPresolvers; ++i )
-             {
-                libpapilo_statistics_t::PresolverStat stat;
-                stat.name = presolvers[i]->getName();
-                stat.ncalls = presolvers[i]->getNCalls();
-                stat.nsuccessful = presolvers[i]->getNSuccess();
-                stat.ntransactions = presolverStats[i].first;
-                stat.napplied = presolverStats[i].second;
-                stat.exectime = presolvers[i]->getExecTime();
-                stats->presolver_stats.push_back( stat );
-             }
-
-             // Set output parameters
-             *reductions_out = reductions;
-             *postsolve_out = postsolve_storage;
-             *statistics_out = stats;
-
-             // Clean up presolve object
-             libpapilo_presolve_free( presolve );
-
-             // Convert status
-             return convert_presolve_status( result.status );
-          },
-          "Failed to apply presolve" );
    }
 
    libpapilo_reductions_t*

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1320,6 +1320,83 @@ extern "C"
       presolve->presolve.getPresolveOptions() = options->options;
    }
 
+   int
+   libpapilo_presolve_set_param_bool( libpapilo_presolve_t* presolve,
+                                      const char* key, int value )
+   {
+      check_presolve_ptr( presolve );
+      custom_assert( key != nullptr, "key pointer is null" );
+
+      try
+      {
+         ParameterSet paramSet = presolve->presolve.getParameters();
+         paramSet.setParameter( key, static_cast<bool>( value ) );
+         return 1;
+      }
+      catch( const std::exception& )
+      {
+         return 0;
+      }
+   }
+
+   int
+   libpapilo_presolve_set_param_int( libpapilo_presolve_t* presolve,
+                                     const char* key, int value )
+   {
+      check_presolve_ptr( presolve );
+      custom_assert( key != nullptr, "key pointer is null" );
+
+      try
+      {
+         ParameterSet paramSet = presolve->presolve.getParameters();
+         paramSet.setParameter( key, value );
+         return 1;
+      }
+      catch( const std::exception& )
+      {
+         return 0;
+      }
+   }
+
+   int
+   libpapilo_presolve_set_param_double( libpapilo_presolve_t* presolve,
+                                        const char* key, double value )
+   {
+      check_presolve_ptr( presolve );
+      custom_assert( key != nullptr, "key pointer is null" );
+
+      try
+      {
+         ParameterSet paramSet = presolve->presolve.getParameters();
+         paramSet.setParameter( key, value );
+         return 1;
+      }
+      catch( const std::exception& )
+      {
+         return 0;
+      }
+   }
+
+   int
+   libpapilo_presolve_parse_param( libpapilo_presolve_t* presolve,
+                                   const char* key, const char* value )
+   {
+      check_presolve_ptr( presolve );
+      custom_assert( key != nullptr, "key pointer is null" );
+      custom_assert( value != nullptr, "value pointer is null" );
+
+      try
+      {
+         ParameterSet paramSet = presolve->presolve.getParameters();
+         paramSet.parseParameter( key, value );
+         return 1;
+      }
+      catch( const std::exception& )
+      {
+         return 0;
+      }
+   }
+
    libpapilo_presolve_status_t
    libpapilo_presolve_apply_simple( libpapilo_presolve_t* presolve,
                                     libpapilo_problem_t* problem )
@@ -1332,6 +1409,42 @@ extern "C"
           {
              PresolveResult<double> result =
                  presolve->presolve.apply( problem->problem );
+             return convert_presolve_status( result.status );
+          },
+          "Failed to apply presolve" );
+   }
+
+   libpapilo_presolve_status_t
+   libpapilo_presolve_apply_full( libpapilo_presolve_t* presolve,
+                                  libpapilo_problem_t* problem,
+                                  libpapilo_postsolve_storage_t** postsolve_out,
+                                  libpapilo_statistics_t** statistics_out )
+   {
+      check_presolve_ptr( presolve );
+      check_problem_ptr( problem );
+      custom_assert( postsolve_out != nullptr,
+                     "postsolve_out pointer is null" );
+      custom_assert( statistics_out != nullptr,
+                     "statistics_out pointer is null" );
+
+      return check_run(
+          [&]()
+          {
+             // Execute presolve
+             PresolveResult<double> result =
+                 presolve->presolve.apply( problem->problem );
+
+             // Create output objects
+             auto* postsolve_storage = new libpapilo_postsolve_storage_t(
+                 std::move( result.postsolve ) );
+             auto* stats = new libpapilo_statistics_t();
+
+             // Copy overall statistics
+             stats->statistics = presolve->presolve.getStatistics();
+
+             *postsolve_out = postsolve_storage;
+             *statistics_out = stats;
+
              return convert_presolve_status( result.status );
           },
           "Failed to apply presolve" );

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1475,6 +1475,26 @@ extern "C"
              // Copy overall statistics
              stats->statistics = presolve->presolve.getStatistics();
 
+             // Copy per-presolver statistics
+             stats->presolver_stats.clear();
+             const auto& presolvers = presolve->presolve.getPresolvers();
+             const auto& presolverStats =
+                 presolve->presolve.getPresolverStats();
+
+             size_t numPresolvers =
+                 std::min( presolvers.size(), presolverStats.size() );
+             for( size_t i = 0; i < numPresolvers; ++i )
+             {
+                libpapilo_statistics_t::PresolverStat stat;
+                stat.name = presolvers[i]->getName();
+                stat.ncalls = presolvers[i]->getNCalls();
+                stat.nsuccessful = presolvers[i]->getNSuccess();
+                stat.ntransactions = presolverStats[i].first;
+                stat.napplied = presolverStats[i].second;
+                stat.exectime = presolvers[i]->getExecTime();
+                stats->presolver_stats.push_back( stat );
+             }
+
              *postsolve_out = postsolve_storage;
              *statistics_out = stats;
 

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -405,6 +405,30 @@ check_run( Func func, const char* message )
    std::terminate();
 }
 
+// Helper function to run parameter operations with proper exception handling
+template <typename Func>
+libpapilo_param_result_t
+run_param_op( Func func )
+{
+   try
+   {
+      func();
+      return LIBPAPILO_PARAM_OK;
+   }
+   catch( const std::invalid_argument& )
+   {
+      return LIBPAPILO_PARAM_NOT_FOUND;
+   }
+   catch( const std::domain_error& )
+   {
+      return LIBPAPILO_PARAM_WRONG_TYPE;
+   }
+   catch( const std::out_of_range& )
+   {
+      return LIBPAPILO_PARAM_INVALID_VALUE;
+   }
+}
+
 // Helper function to convert PresolveStatus to libpapilo_presolve_status_t
 static libpapilo_presolve_status_t
 convert_presolve_status( PresolveStatus status )
@@ -1327,24 +1351,12 @@ extern "C"
       check_presolve_ptr( presolve );
       custom_assert( key != nullptr, "key pointer is null" );
 
-      try
-      {
-         ParameterSet paramSet = presolve->presolve.getParameters();
-         paramSet.setParameter( key, static_cast<bool>( value ) );
-         return LIBPAPILO_PARAM_OK;
-      }
-      catch( const std::invalid_argument& )
-      {
-         return LIBPAPILO_PARAM_NOT_FOUND;
-      }
-      catch( const std::domain_error& )
-      {
-         return LIBPAPILO_PARAM_WRONG_TYPE;
-      }
-      catch( const std::out_of_range& )
-      {
-         return LIBPAPILO_PARAM_INVALID_VALUE;
-      }
+      return run_param_op(
+          [&]()
+          {
+             ParameterSet paramSet = presolve->presolve.getParameters();
+             paramSet.setParameter( key, static_cast<bool>( value ) );
+          } );
    }
 
    libpapilo_param_result_t
@@ -1354,24 +1366,12 @@ extern "C"
       check_presolve_ptr( presolve );
       custom_assert( key != nullptr, "key pointer is null" );
 
-      try
-      {
-         ParameterSet paramSet = presolve->presolve.getParameters();
-         paramSet.setParameter( key, value );
-         return LIBPAPILO_PARAM_OK;
-      }
-      catch( const std::invalid_argument& )
-      {
-         return LIBPAPILO_PARAM_NOT_FOUND;
-      }
-      catch( const std::domain_error& )
-      {
-         return LIBPAPILO_PARAM_WRONG_TYPE;
-      }
-      catch( const std::out_of_range& )
-      {
-         return LIBPAPILO_PARAM_INVALID_VALUE;
-      }
+      return run_param_op(
+          [&]()
+          {
+             ParameterSet paramSet = presolve->presolve.getParameters();
+             paramSet.setParameter( key, value );
+          } );
    }
 
    libpapilo_param_result_t
@@ -1381,24 +1381,12 @@ extern "C"
       check_presolve_ptr( presolve );
       custom_assert( key != nullptr, "key pointer is null" );
 
-      try
-      {
-         ParameterSet paramSet = presolve->presolve.getParameters();
-         paramSet.setParameter( key, value );
-         return LIBPAPILO_PARAM_OK;
-      }
-      catch( const std::invalid_argument& )
-      {
-         return LIBPAPILO_PARAM_NOT_FOUND;
-      }
-      catch( const std::domain_error& )
-      {
-         return LIBPAPILO_PARAM_WRONG_TYPE;
-      }
-      catch( const std::out_of_range& )
-      {
-         return LIBPAPILO_PARAM_INVALID_VALUE;
-      }
+      return run_param_op(
+          [&]()
+          {
+             ParameterSet paramSet = presolve->presolve.getParameters();
+             paramSet.setParameter( key, value );
+          } );
    }
 
    libpapilo_param_result_t
@@ -1409,25 +1397,12 @@ extern "C"
       custom_assert( key != nullptr, "key pointer is null" );
       custom_assert( value != nullptr, "value pointer is null" );
 
-      try
-      {
-         ParameterSet paramSet = presolve->presolve.getParameters();
-         paramSet.parseParameter( key, value );
-         return LIBPAPILO_PARAM_OK;
-      }
-      catch( const std::invalid_argument& )
-      {
-         // Could be "parameter not found" or "could not parse"
-         return LIBPAPILO_PARAM_NOT_FOUND;
-      }
-      catch( const std::domain_error& )
-      {
-         return LIBPAPILO_PARAM_WRONG_TYPE;
-      }
-      catch( const std::out_of_range& )
-      {
-         return LIBPAPILO_PARAM_INVALID_VALUE;
-      }
+      return run_param_op(
+          [&]()
+          {
+             ParameterSet paramSet = presolve->presolve.getParameters();
+             paramSet.parseParameter( key, value );
+          } );
    }
 
    libpapilo_presolve_status_t

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -1320,7 +1320,7 @@ extern "C"
       presolve->presolve.getPresolveOptions() = options->options;
    }
 
-   int
+   libpapilo_param_result_t
    libpapilo_presolve_set_param_bool( libpapilo_presolve_t* presolve,
                                       const char* key, int value )
    {
@@ -1331,15 +1331,23 @@ extern "C"
       {
          ParameterSet paramSet = presolve->presolve.getParameters();
          paramSet.setParameter( key, static_cast<bool>( value ) );
-         return 1;
+         return LIBPAPILO_PARAM_OK;
       }
-      catch( const std::exception& )
+      catch( const std::invalid_argument& )
       {
-         return 0;
+         return LIBPAPILO_PARAM_NOT_FOUND;
+      }
+      catch( const std::domain_error& )
+      {
+         return LIBPAPILO_PARAM_WRONG_TYPE;
+      }
+      catch( const std::out_of_range& )
+      {
+         return LIBPAPILO_PARAM_INVALID_VALUE;
       }
    }
 
-   int
+   libpapilo_param_result_t
    libpapilo_presolve_set_param_int( libpapilo_presolve_t* presolve,
                                      const char* key, int value )
    {
@@ -1350,15 +1358,23 @@ extern "C"
       {
          ParameterSet paramSet = presolve->presolve.getParameters();
          paramSet.setParameter( key, value );
-         return 1;
+         return LIBPAPILO_PARAM_OK;
       }
-      catch( const std::exception& )
+      catch( const std::invalid_argument& )
       {
-         return 0;
+         return LIBPAPILO_PARAM_NOT_FOUND;
+      }
+      catch( const std::domain_error& )
+      {
+         return LIBPAPILO_PARAM_WRONG_TYPE;
+      }
+      catch( const std::out_of_range& )
+      {
+         return LIBPAPILO_PARAM_INVALID_VALUE;
       }
    }
 
-   int
+   libpapilo_param_result_t
    libpapilo_presolve_set_param_double( libpapilo_presolve_t* presolve,
                                         const char* key, double value )
    {
@@ -1369,15 +1385,23 @@ extern "C"
       {
          ParameterSet paramSet = presolve->presolve.getParameters();
          paramSet.setParameter( key, value );
-         return 1;
+         return LIBPAPILO_PARAM_OK;
       }
-      catch( const std::exception& )
+      catch( const std::invalid_argument& )
       {
-         return 0;
+         return LIBPAPILO_PARAM_NOT_FOUND;
+      }
+      catch( const std::domain_error& )
+      {
+         return LIBPAPILO_PARAM_WRONG_TYPE;
+      }
+      catch( const std::out_of_range& )
+      {
+         return LIBPAPILO_PARAM_INVALID_VALUE;
       }
    }
 
-   int
+   libpapilo_param_result_t
    libpapilo_presolve_parse_param( libpapilo_presolve_t* presolve,
                                    const char* key, const char* value )
    {
@@ -1389,11 +1413,20 @@ extern "C"
       {
          ParameterSet paramSet = presolve->presolve.getParameters();
          paramSet.parseParameter( key, value );
-         return 1;
+         return LIBPAPILO_PARAM_OK;
       }
-      catch( const std::exception& )
+      catch( const std::invalid_argument& )
       {
-         return 0;
+         // Could be "parameter not found" or "could not parse"
+         return LIBPAPILO_PARAM_NOT_FOUND;
+      }
+      catch( const std::domain_error& )
+      {
+         return LIBPAPILO_PARAM_WRONG_TYPE;
+      }
+      catch( const std::out_of_range& )
+      {
+         return LIBPAPILO_PARAM_INVALID_VALUE;
       }
    }
 

--- a/src/libpapilo.cpp
+++ b/src/libpapilo.cpp
@@ -415,8 +415,13 @@ run_param_op( Func func )
       func();
       return LIBPAPILO_PARAM_OK;
    }
-   catch( const std::invalid_argument& )
+   catch( const std::invalid_argument& e )
    {
+      // ParameterSet uses std::invalid_argument for both missing keys and
+      // parse errors. Distinguish based on exception message.
+      const std::string msg( e.what() );
+      if( msg.find( "could not parse" ) != std::string::npos )
+         return LIBPAPILO_PARAM_INVALID_VALUE;
       return LIBPAPILO_PARAM_NOT_FOUND;
    }
    catch( const std::domain_error& )
@@ -425,6 +430,16 @@ run_param_op( Func func )
    }
    catch( const std::out_of_range& )
    {
+      return LIBPAPILO_PARAM_INVALID_VALUE;
+   }
+   catch( const std::exception& )
+   {
+      // Catch any other standard exceptions to prevent crossing C boundary
+      return LIBPAPILO_PARAM_INVALID_VALUE;
+   }
+   catch( ... )
+   {
+      // Catch-all for non-standard exceptions
       return LIBPAPILO_PARAM_INVALID_VALUE;
    }
 }

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -656,16 +656,11 @@ extern "C"
    libpapilo_presolve_parse_param( libpapilo_presolve_t* presolve,
                                    const char* key, const char* value );
 
-   LIBPAPILO_EXPORT libpapilo_presolve_status_t
-   libpapilo_presolve_apply_simple( libpapilo_presolve_t* presolve,
-                                    libpapilo_problem_t* problem );
-
    /**
     * Apply presolve using the given presolve object with full output.
     *
-    * Unlike libpapilo_presolve_apply which creates its own presolve object,
-    * this function uses the provided presolve object, allowing you to configure
-    * parameters before running.
+    * This is the main presolve function. Create a presolve object, add
+    * presolvers, optionally configure parameters, then call this function.
     *
     * @param presolve The configured presolve object (must have presolvers
     * added)
@@ -730,15 +725,6 @@ extern "C"
    LIBPAPILO_EXPORT unsigned int
    libpapilo_presolve_options_get_randomseed(
        const libpapilo_presolve_options_t* options );
-
-   /* Main presolve function */
-   LIBPAPILO_EXPORT libpapilo_presolve_status_t
-   libpapilo_presolve_apply( libpapilo_problem_t* problem,
-                             const libpapilo_presolve_options_t* options,
-                             const libpapilo_message_t* message,
-                             libpapilo_reductions_t** reductions,
-                             libpapilo_postsolve_storage_t** postsolve,
-                             libpapilo_statistics_t** statistics );
 
    /* Reductions access API */
    LIBPAPILO_EXPORT libpapilo_reductions_t*

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -578,9 +578,91 @@ extern "C"
        libpapilo_presolve_t* presolve,
        const libpapilo_presolve_options_t* options );
 
+   /**
+    * Set a boolean parameter on the presolve object.
+    *
+    * This function allows configuring presolvers and presolve options using
+    * parameter keys. Common parameter keys include:
+    * - "parallelcols.enabled": Enable/disable parallel column detection
+    * - "parallelrows.enabled": Enable/disable parallel row detection
+    * - "probing.enabled": Enable/disable probing
+    * - "propagation.enabled": Enable/disable propagation
+    * - etc.
+    *
+    * Note: Presolvers must be added (via add_default_presolvers) before their
+    * parameters can be set.
+    *
+    * @param presolve The presolve object
+    * @param key The parameter key (e.g., "parallelcols.enabled")
+    * @param value The boolean value to set
+    * @return 1 on success, 0 if parameter not found or type mismatch
+    */
+   LIBPAPILO_EXPORT int
+   libpapilo_presolve_set_param_bool( libpapilo_presolve_t* presolve,
+                                      const char* key, int value );
+
+   /**
+    * Set an integer parameter on the presolve object.
+    *
+    * @param presolve The presolve object
+    * @param key The parameter key
+    * @param value The integer value to set
+    * @return 1 on success, 0 if parameter not found or type mismatch
+    */
+   LIBPAPILO_EXPORT int
+   libpapilo_presolve_set_param_int( libpapilo_presolve_t* presolve,
+                                     const char* key, int value );
+
+   /**
+    * Set a double parameter on the presolve object.
+    *
+    * @param presolve The presolve object
+    * @param key The parameter key
+    * @param value The double value to set
+    * @return 1 on success, 0 if parameter not found or type mismatch
+    */
+   LIBPAPILO_EXPORT int
+   libpapilo_presolve_set_param_double( libpapilo_presolve_t* presolve,
+                                        const char* key, double value );
+
+   /**
+    * Set a parameter by parsing a string value.
+    *
+    * This function parses the string value according to the parameter's type.
+    * For boolean parameters, "0" or "1" are expected.
+    *
+    * @param presolve The presolve object
+    * @param key The parameter key
+    * @param value The string value to parse
+    * @return 1 on success, 0 if parameter not found or parse error
+    */
+   LIBPAPILO_EXPORT int
+   libpapilo_presolve_parse_param( libpapilo_presolve_t* presolve,
+                                   const char* key, const char* value );
+
    LIBPAPILO_EXPORT libpapilo_presolve_status_t
    libpapilo_presolve_apply_simple( libpapilo_presolve_t* presolve,
                                     libpapilo_problem_t* problem );
+
+   /**
+    * Apply presolve using the given presolve object with full output.
+    *
+    * Unlike libpapilo_presolve_apply which creates its own presolve object,
+    * this function uses the provided presolve object, allowing you to configure
+    * parameters before running.
+    *
+    * @param presolve The configured presolve object (must have presolvers
+    * added)
+    * @param problem The problem to presolve (will be modified in-place)
+    * @param postsolve_out Output: postsolve storage for solution recovery
+    * @param statistics_out Output: statistics about the presolve process
+    * @return Presolve status indicating the result
+    */
+   LIBPAPILO_EXPORT libpapilo_presolve_status_t
+   libpapilo_presolve_apply_full( libpapilo_presolve_t* presolve,
+                                  libpapilo_problem_t* problem,
+                                  libpapilo_postsolve_storage_t** postsolve_out,
+                                  libpapilo_statistics_t** statistics_out );
 
    LIBPAPILO_EXPORT void
    libpapilo_presolve_apply_reductions( libpapilo_presolve_t* presolve,

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -644,13 +644,15 @@ extern "C"
     * Set a parameter by parsing a string value.
     *
     * This function parses the string value according to the parameter's type.
-    * For boolean parameters, numeric strings are parsed (0 = false, non-zero =
-    * true). Non-numeric strings will cause a parse error.
+    * For boolean parameters, the value must be "0" or "1". Other values will
+    * cause a parse error and return LIBPAPILO_PARAM_INVALID_VALUE.
     *
     * @param presolve The presolve object
     * @param key The parameter key
     * @param value The string value to parse
-    * @return LIBPAPILO_PARAM_OK on success, or an error code
+    * @return LIBPAPILO_PARAM_OK on success, LIBPAPILO_PARAM_NOT_FOUND if
+    *         the key does not exist, or LIBPAPILO_PARAM_INVALID_VALUE if
+    *         the value could not be parsed
     */
    LIBPAPILO_EXPORT libpapilo_param_result_t
    libpapilo_presolve_parse_param( libpapilo_presolve_t* presolve,

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -644,7 +644,8 @@ extern "C"
     * Set a parameter by parsing a string value.
     *
     * This function parses the string value according to the parameter's type.
-    * For boolean parameters, "0" or "1" are expected.
+    * For boolean parameters, numeric strings are parsed (0 = false, non-zero =
+    * true). Non-numeric strings will cause a parse error.
     *
     * @param presolve The presolve object
     * @param key The parameter key

--- a/src/libpapilo.h
+++ b/src/libpapilo.h
@@ -249,6 +249,21 @@ extern "C"
       LIBPAPILO_ROW_REDUCTION_PARALLEL_ROW = -16
    } libpapilo_row_reduction_t;
 
+   /**
+    * Result of parameter setting operations.
+    */
+   typedef enum
+   {
+      /** Parameter was successfully set */
+      LIBPAPILO_PARAM_OK = 0,
+      /** Parameter key was not found */
+      LIBPAPILO_PARAM_NOT_FOUND = 1,
+      /** Value type does not match parameter type */
+      LIBPAPILO_PARAM_WRONG_TYPE = 2,
+      /** Value is out of valid range or could not be parsed */
+      LIBPAPILO_PARAM_INVALID_VALUE = 3
+   } libpapilo_param_result_t;
+
    /** Reduction info structure */
    typedef struct
    {
@@ -595,9 +610,9 @@ extern "C"
     * @param presolve The presolve object
     * @param key The parameter key (e.g., "parallelcols.enabled")
     * @param value The boolean value to set
-    * @return 1 on success, 0 if parameter not found or type mismatch
+    * @return LIBPAPILO_PARAM_OK on success, or an error code
     */
-   LIBPAPILO_EXPORT int
+   LIBPAPILO_EXPORT libpapilo_param_result_t
    libpapilo_presolve_set_param_bool( libpapilo_presolve_t* presolve,
                                       const char* key, int value );
 
@@ -607,9 +622,9 @@ extern "C"
     * @param presolve The presolve object
     * @param key The parameter key
     * @param value The integer value to set
-    * @return 1 on success, 0 if parameter not found or type mismatch
+    * @return LIBPAPILO_PARAM_OK on success, or an error code
     */
-   LIBPAPILO_EXPORT int
+   LIBPAPILO_EXPORT libpapilo_param_result_t
    libpapilo_presolve_set_param_int( libpapilo_presolve_t* presolve,
                                      const char* key, int value );
 
@@ -619,9 +634,9 @@ extern "C"
     * @param presolve The presolve object
     * @param key The parameter key
     * @param value The double value to set
-    * @return 1 on success, 0 if parameter not found or type mismatch
+    * @return LIBPAPILO_PARAM_OK on success, or an error code
     */
-   LIBPAPILO_EXPORT int
+   LIBPAPILO_EXPORT libpapilo_param_result_t
    libpapilo_presolve_set_param_double( libpapilo_presolve_t* presolve,
                                         const char* key, double value );
 
@@ -634,9 +649,9 @@ extern "C"
     * @param presolve The presolve object
     * @param key The parameter key
     * @param value The string value to parse
-    * @return 1 on success, 0 if parameter not found or parse error
+    * @return LIBPAPILO_PARAM_OK on success, or an error code
     */
-   LIBPAPILO_EXPORT int
+   LIBPAPILO_EXPORT libpapilo_param_result_t
    libpapilo_presolve_parse_param( libpapilo_presolve_t* presolve,
                                    const char* key, const char* value );
 

--- a/test/libpapilo/CMakeLists.txt
+++ b/test/libpapilo/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBPAPILO_TESTS
     GetterAPIsTest.cpp
     PresolverStatsTest.cpp
     ParallelColDetectionTest.cpp
+    ParameterTest.cpp
     # Add more test files as needed
 )
 
@@ -100,6 +101,15 @@ set(LIBPAPILO_TEST_NAMES
     "parallel_col_detection_int_merge_failed_hole"
     "parallel_col_detection_obj_not_parallel"
     "parallel_col_detection_multiple_parallel_columns"
+
+    # ParameterTest.cpp
+    "set_param_bool disables presolver"
+    "set_param_bool returns 0 for unknown key"
+    "set_param_int sets integer parameter"
+    "parse_param parses string value"
+    "parse_param returns 0 for parse error"
+    "set_param_bool fails before presolvers are added"
+    "disabling parallelcols prevents parallel column detection"
 )
 
 # Register test targets for each test file

--- a/test/libpapilo/CMakeLists.txt
+++ b/test/libpapilo/CMakeLists.txt
@@ -106,6 +106,7 @@ set(LIBPAPILO_TEST_NAMES
     "set-param-bool-disables-presolver"
     "set-param-bool-returns-not-found-for-unknown-key"
     "set-param-int-sets-integer-parameter"
+    "set-param-double-sets-double-parameter"
     "parse-param-parses-string-value"
     "parse-param-returns-not-found-for-parse-error"
     "set-param-bool-returns-not-found-before-presolvers-added"

--- a/test/libpapilo/CMakeLists.txt
+++ b/test/libpapilo/CMakeLists.txt
@@ -103,13 +103,13 @@ set(LIBPAPILO_TEST_NAMES
     "parallel_col_detection_multiple_parallel_columns"
 
     # ParameterTest.cpp
-    "set_param_bool disables presolver"
-    "set_param_bool returns NOT_FOUND for unknown key"
-    "set_param_int sets integer parameter"
-    "parse_param parses string value"
-    "parse_param returns NOT_FOUND for parse error"
-    "set_param_bool returns NOT_FOUND before presolvers are added"
-    "disabling parallelcols prevents parallel column detection"
+    "set-param-bool-disables-presolver"
+    "set-param-bool-returns-not-found-for-unknown-key"
+    "set-param-int-sets-integer-parameter"
+    "parse-param-parses-string-value"
+    "parse-param-returns-not-found-for-parse-error"
+    "set-param-bool-returns-not-found-before-presolvers-added"
+    "disabling-parallelcols-prevents-parallel-column-detection"
 )
 
 # Register test targets for each test file

--- a/test/libpapilo/CMakeLists.txt
+++ b/test/libpapilo/CMakeLists.txt
@@ -104,11 +104,11 @@ set(LIBPAPILO_TEST_NAMES
 
     # ParameterTest.cpp
     "set_param_bool disables presolver"
-    "set_param_bool returns 0 for unknown key"
+    "set_param_bool returns NOT_FOUND for unknown key"
     "set_param_int sets integer parameter"
     "parse_param parses string value"
-    "parse_param returns 0 for parse error"
-    "set_param_bool fails before presolvers are added"
+    "parse_param returns NOT_FOUND for parse error"
+    "set_param_bool returns NOT_FOUND before presolvers are added"
     "disabling parallelcols prevents parallel column detection"
 )
 

--- a/test/libpapilo/CMakeLists.txt
+++ b/test/libpapilo/CMakeLists.txt
@@ -108,7 +108,7 @@ set(LIBPAPILO_TEST_NAMES
     "set-param-int-sets-integer-parameter"
     "set-param-double-sets-double-parameter"
     "parse-param-parses-string-value"
-    "parse-param-returns-not-found-for-parse-error"
+    "parse-param-returns-invalid-value-for-parse-error"
     "set-param-bool-returns-not-found-before-presolvers-added"
     "disabling-parallelcols-prevents-parallel-column-detection"
 )

--- a/test/libpapilo/ParameterTest.cpp
+++ b/test/libpapilo/ParameterTest.cpp
@@ -1,0 +1,297 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                           */
+/* This file is part of the library libpapilo, a fork of PaPILO from ZIB     */
+/*                                                                           */
+/* Copyright (C) 2020-2025 Zuse Institute Berlin (ZIB)                       */
+/* Copyright (C) 2025      Jij-Inc.                                          */
+/*                                                                           */
+/* Licensed under the Apache License, Version 2.0 (the "License");           */
+/* you may not use this file except in compliance with the License.          */
+/* You may obtain a copy of the License at                                   */
+/*                                                                           */
+/*     http://www.apache.org/licenses/LICENSE-2.0                            */
+/*                                                                           */
+/* Unless required by applicable law or agreed to in writing, software       */
+/* distributed under the License is distributed on an "AS IS" BASIS,         */
+/* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  */
+/* See the License for the specific language governing permissions and       */
+/* limitations under the License.                                            */
+/*                                                                           */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "libpapilo.h"
+#include "papilo/external/catch/catch_amalgamated.hpp"
+#include <cstring>
+
+TEST_CASE( "set_param_bool disables presolver", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
+   // Disable parallel column detection
+   int result =
+       libpapilo_presolve_set_param_bool( presolve, "parallelcols.enabled", 0 );
+   REQUIRE( result == 1 );
+
+   // Disable parallel row detection
+   result =
+       libpapilo_presolve_set_param_bool( presolve, "parallelrows.enabled", 0 );
+   REQUIRE( result == 1 );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
+TEST_CASE( "set_param_bool returns 0 for unknown key", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
+   int result =
+       libpapilo_presolve_set_param_bool( presolve, "unknown.parameter", 1 );
+   REQUIRE( result == 0 );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
+TEST_CASE( "set_param_int sets integer parameter", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
+   // Set message verbosity level
+   int result =
+       libpapilo_presolve_set_param_int( presolve, "message.verbosity", 0 );
+   REQUIRE( result == 1 );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
+TEST_CASE( "parse_param parses string value", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
+   // Parse "0" as false for boolean parameter
+   int result =
+       libpapilo_presolve_parse_param( presolve, "parallelcols.enabled", "0" );
+   REQUIRE( result == 1 );
+
+   // Parse "1" as true
+   result =
+       libpapilo_presolve_parse_param( presolve, "parallelcols.enabled", "1" );
+   REQUIRE( result == 1 );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
+TEST_CASE( "parse_param returns 0 for parse error", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
+   // Invalid value for boolean parameter
+   int result = libpapilo_presolve_parse_param( presolve,
+                                                "parallelcols.enabled", "abc" );
+   REQUIRE( result == 0 );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
+TEST_CASE( "set_param_bool fails before presolvers are added", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   // Note: NOT calling add_default_presolvers
+
+   // This should fail because parallelcols presolver is not added yet
+   int result =
+       libpapilo_presolve_set_param_bool( presolve, "parallelcols.enabled", 0 );
+   REQUIRE( result == 0 );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
+// Helper function to create a problem with parallel columns
+// (same structure as ParallelColDetectionTest.cpp)
+static libpapilo_problem_t*
+createProblemWithParallelColumns()
+{
+   libpapilo_problem_builder_t* builder = libpapilo_problem_builder_create();
+
+   libpapilo_problem_builder_set_num_rows( builder, 2 );
+   libpapilo_problem_builder_set_num_cols( builder, 2 );
+   libpapilo_problem_builder_reserve( builder, 4, 2, 2 );
+
+   // Set objective coefficients (parallel: obj[1] = 3 * obj[0])
+   double obj[] = { 1.0, 3.0 };
+   libpapilo_problem_builder_set_obj_all( builder, obj );
+   libpapilo_problem_builder_set_obj_offset( builder, 0.0 );
+
+   // Set variable bounds
+   double lb[] = { 0.0, 0.0 };
+   double ub[] = { 10.0, 10.0 };
+   libpapilo_problem_builder_set_col_lb_all( builder, lb );
+   libpapilo_problem_builder_set_col_ub_all( builder, ub );
+
+   // Set variables as integral
+   uint8_t integral[] = { 1, 1 };
+   libpapilo_problem_builder_set_col_integral_all( builder, integral );
+
+   // Set row bounds (equality constraints)
+   double rhs[] = { 1.0, 2.0 };
+   double lhs[] = { 1.0, 2.0 };
+   libpapilo_problem_builder_set_row_rhs_all( builder, rhs );
+   libpapilo_problem_builder_set_row_lhs_all( builder, lhs );
+
+   // Add matrix entries with parallel structure:
+   // Row 0: 1.0 * col0 + 3.0 * col1 = 1
+   // Row 1: 2.0 * col0 + 6.0 * col1 = 2
+   libpapilo_problem_builder_add_entry( builder, 0, 0, 1.0 );
+   libpapilo_problem_builder_add_entry( builder, 0, 1, 3.0 );
+   libpapilo_problem_builder_add_entry( builder, 1, 0, 2.0 );
+   libpapilo_problem_builder_add_entry( builder, 1, 1, 6.0 );
+
+   libpapilo_problem_builder_set_problem_name( builder, "parallel_cols_test" );
+
+   libpapilo_problem_t* problem = libpapilo_problem_builder_build( builder );
+   libpapilo_problem_builder_free( builder );
+
+   return problem;
+}
+
+// Helper function to check if postsolve contains PARALLEL_COL reduction
+static bool
+postsolveContainsParallelCol( libpapilo_postsolve_storage_t* postsolve )
+{
+   size_t size = 0;
+   const libpapilo_postsolve_reduction_type_t* types =
+       libpapilo_postsolve_storage_get_types( postsolve, &size );
+
+   if( types == nullptr )
+      return false;
+
+   for( size_t i = 0; i < size; ++i )
+   {
+      if( types[i] == LIBPAPILO_POSTSOLVE_REDUCTION_PARALLEL_COL )
+         return true;
+   }
+   return false;
+}
+
+// Helper function to disable all presolvers except the ones we want to test
+static void
+disableAllPresolversExcept( libpapilo_presolve_t* presolve,
+                            const char* keepEnabled )
+{
+   // Disable all common presolvers
+   const char* presolvers[] = {
+       "coefftightening.enabled", "colsingleton.enabled",
+       "domcol.enabled",          "doubletoneq.enabled",
+       "dualfix.enabled",         "dualinfer.enabled",
+       "fixcontinuous.enabled",   "implint.enabled",
+       "parallelcols.enabled",    "parallelrows.enabled",
+       "probing.enabled",         "propagation.enabled",
+       "simpleprobing.enabled",   "simplifyineq.enabled",
+       "sparsify.enabled",        "stuffing.enabled",
+       "substitution.enabled" };
+
+   for( const char* p : presolvers )
+   {
+      if( strcmp( p, keepEnabled ) != 0 )
+      {
+         libpapilo_presolve_set_param_bool( presolve, p, 0 );
+      }
+   }
+}
+
+TEST_CASE( "disabling parallelcols prevents parallel column detection",
+           "[parameter][behavior]" )
+{
+   // Test 1: With ONLY parallelcols enabled, parallel columns should be
+   // detected
+   {
+      libpapilo_problem_t* problem = createProblemWithParallelColumns();
+      libpapilo_message_t* message = libpapilo_message_create();
+      libpapilo_message_set_verbosity_level( message, 0 ); // quiet
+
+      libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+      libpapilo_presolve_add_default_presolvers( presolve );
+
+      // Disable all presolvers except parallelcols
+      disableAllPresolversExcept( presolve, "parallelcols.enabled" );
+
+      // Explicitly enable parallel column detection
+      int result = libpapilo_presolve_set_param_bool(
+          presolve, "parallelcols.enabled", 1 );
+      REQUIRE( result == 1 );
+
+      libpapilo_postsolve_storage_t* postsolve = nullptr;
+      libpapilo_statistics_t* statistics = nullptr;
+
+      libpapilo_presolve_status_t status = libpapilo_presolve_apply_full(
+          presolve, problem, &postsolve, &statistics );
+      (void)status; // unused in this test
+
+      // Check that parallel columns were detected
+      REQUIRE( postsolve != nullptr );
+      bool hasParallelCol = postsolveContainsParallelCol( postsolve );
+      INFO( "With parallelcols.enabled=1, PARALLEL_COL should be detected" );
+      REQUIRE( hasParallelCol == true );
+
+      // Cleanup
+      libpapilo_statistics_free( statistics );
+      libpapilo_postsolve_storage_free( postsolve );
+      libpapilo_presolve_free( presolve );
+      libpapilo_message_free( message );
+      libpapilo_problem_free( problem );
+   }
+
+   // Test 2: With parallelcols disabled (and all others disabled too),
+   // no PARALLEL_COL reduction should occur
+   {
+      libpapilo_problem_t* problem = createProblemWithParallelColumns();
+      libpapilo_message_t* message = libpapilo_message_create();
+      libpapilo_message_set_verbosity_level( message, 0 ); // quiet
+
+      libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+      libpapilo_presolve_add_default_presolvers( presolve );
+
+      // Disable ALL presolvers including parallelcols
+      disableAllPresolversExcept( presolve, "" ); // empty = disable all
+      int result = libpapilo_presolve_set_param_bool(
+          presolve, "parallelcols.enabled", 0 );
+      REQUIRE( result == 1 );
+
+      libpapilo_postsolve_storage_t* postsolve = nullptr;
+      libpapilo_statistics_t* statistics = nullptr;
+
+      libpapilo_presolve_status_t status = libpapilo_presolve_apply_full(
+          presolve, problem, &postsolve, &statistics );
+      (void)status; // unused in this test
+
+      // Check that parallel columns were NOT detected
+      REQUIRE( postsolve != nullptr );
+      bool hasParallelCol = postsolveContainsParallelCol( postsolve );
+      INFO(
+          "With parallelcols.enabled=0, PARALLEL_COL should NOT be detected" );
+      REQUIRE( hasParallelCol == false );
+
+      // Cleanup
+      libpapilo_statistics_free( statistics );
+      libpapilo_postsolve_storage_free( postsolve );
+      libpapilo_presolve_free( presolve );
+      libpapilo_message_free( message );
+      libpapilo_problem_free( problem );
+   }
+}

--- a/test/libpapilo/ParameterTest.cpp
+++ b/test/libpapilo/ParameterTest.cpp
@@ -26,7 +26,9 @@
 TEST_CASE( "set-param-bool-disables-presolver", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Disable parallel column detection
@@ -46,7 +48,9 @@ TEST_CASE( "set-param-bool-disables-presolver", "[parameter]" )
 TEST_CASE( "set-param-bool-returns-not-found-for-unknown-key", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    libpapilo_presolve_add_default_presolvers( presolve );
 
    libpapilo_param_result_t result =
@@ -60,7 +64,9 @@ TEST_CASE( "set-param-bool-returns-not-found-for-unknown-key", "[parameter]" )
 TEST_CASE( "set-param-int-sets-integer-parameter", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Set message verbosity level
@@ -75,7 +81,9 @@ TEST_CASE( "set-param-int-sets-integer-parameter", "[parameter]" )
 TEST_CASE( "set-param-double-sets-double-parameter", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Set numerics.feastol parameter
@@ -95,7 +103,9 @@ TEST_CASE( "set-param-double-sets-double-parameter", "[parameter]" )
 TEST_CASE( "parse-param-parses-string-value", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Parse "0" as false for boolean parameter
@@ -112,17 +122,18 @@ TEST_CASE( "parse-param-parses-string-value", "[parameter]" )
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "parse-param-returns-not-found-for-parse-error", "[parameter]" )
+TEST_CASE( "parse-param-returns-invalid-value-for-parse-error", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    libpapilo_presolve_add_default_presolvers( presolve );
 
-   // Invalid value for boolean parameter - boost::lexical_cast throws
-   // invalid_argument
+   // Invalid value for boolean parameter - returns INVALID_VALUE
    libpapilo_param_result_t result = libpapilo_presolve_parse_param(
        presolve, "parallelcols.enabled", "abc" );
-   REQUIRE( result == LIBPAPILO_PARAM_NOT_FOUND );
+   REQUIRE( result == LIBPAPILO_PARAM_INVALID_VALUE );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
@@ -132,7 +143,9 @@ TEST_CASE( "set-param-bool-returns-not-found-before-presolvers-added",
            "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
+   REQUIRE( message != nullptr );
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
    // Note: NOT calling add_default_presolvers
 
    // This should fail because parallelcols presolver is not added yet
@@ -150,6 +163,8 @@ static libpapilo_problem_t*
 createProblemWithParallelColumns()
 {
    libpapilo_problem_builder_t* builder = libpapilo_problem_builder_create();
+   if( builder == nullptr )
+      return nullptr;
 
    libpapilo_problem_builder_set_num_rows( builder, 2 );
    libpapilo_problem_builder_set_num_cols( builder, 2 );

--- a/test/libpapilo/ParameterTest.cpp
+++ b/test/libpapilo/ParameterTest.cpp
@@ -30,28 +30,28 @@ TEST_CASE( "set_param_bool disables presolver", "[parameter]" )
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Disable parallel column detection
-   int result =
+   libpapilo_param_result_t result =
        libpapilo_presolve_set_param_bool( presolve, "parallelcols.enabled", 0 );
-   REQUIRE( result == 1 );
+   REQUIRE( result == LIBPAPILO_PARAM_OK );
 
    // Disable parallel row detection
    result =
        libpapilo_presolve_set_param_bool( presolve, "parallelrows.enabled", 0 );
-   REQUIRE( result == 1 );
+   REQUIRE( result == LIBPAPILO_PARAM_OK );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "set_param_bool returns 0 for unknown key", "[parameter]" )
+TEST_CASE( "set_param_bool returns NOT_FOUND for unknown key", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
    libpapilo_presolve_add_default_presolvers( presolve );
 
-   int result =
+   libpapilo_param_result_t result =
        libpapilo_presolve_set_param_bool( presolve, "unknown.parameter", 1 );
-   REQUIRE( result == 0 );
+   REQUIRE( result == LIBPAPILO_PARAM_NOT_FOUND );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
@@ -64,9 +64,9 @@ TEST_CASE( "set_param_int sets integer parameter", "[parameter]" )
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Set message verbosity level
-   int result =
+   libpapilo_param_result_t result =
        libpapilo_presolve_set_param_int( presolve, "message.verbosity", 0 );
-   REQUIRE( result == 1 );
+   REQUIRE( result == LIBPAPILO_PARAM_OK );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
@@ -79,44 +79,46 @@ TEST_CASE( "parse_param parses string value", "[parameter]" )
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Parse "0" as false for boolean parameter
-   int result =
+   libpapilo_param_result_t result =
        libpapilo_presolve_parse_param( presolve, "parallelcols.enabled", "0" );
-   REQUIRE( result == 1 );
+   REQUIRE( result == LIBPAPILO_PARAM_OK );
 
    // Parse "1" as true
    result =
        libpapilo_presolve_parse_param( presolve, "parallelcols.enabled", "1" );
-   REQUIRE( result == 1 );
+   REQUIRE( result == LIBPAPILO_PARAM_OK );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "parse_param returns 0 for parse error", "[parameter]" )
+TEST_CASE( "parse_param returns NOT_FOUND for parse error", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
    libpapilo_presolve_add_default_presolvers( presolve );
 
-   // Invalid value for boolean parameter
-   int result = libpapilo_presolve_parse_param( presolve,
-                                                "parallelcols.enabled", "abc" );
-   REQUIRE( result == 0 );
+   // Invalid value for boolean parameter - boost::lexical_cast throws
+   // invalid_argument
+   libpapilo_param_result_t result = libpapilo_presolve_parse_param(
+       presolve, "parallelcols.enabled", "abc" );
+   REQUIRE( result == LIBPAPILO_PARAM_NOT_FOUND );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "set_param_bool fails before presolvers are added", "[parameter]" )
+TEST_CASE( "set_param_bool returns NOT_FOUND before presolvers are added",
+           "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
    // Note: NOT calling add_default_presolvers
 
    // This should fail because parallelcols presolver is not added yet
-   int result =
+   libpapilo_param_result_t result =
        libpapilo_presolve_set_param_bool( presolve, "parallelcols.enabled", 0 );
-   REQUIRE( result == 0 );
+   REQUIRE( result == LIBPAPILO_PARAM_NOT_FOUND );
 
    libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
@@ -232,9 +234,9 @@ TEST_CASE( "disabling parallelcols prevents parallel column detection",
       disableAllPresolversExcept( presolve, "parallelcols.enabled" );
 
       // Explicitly enable parallel column detection
-      int result = libpapilo_presolve_set_param_bool(
+      libpapilo_param_result_t result = libpapilo_presolve_set_param_bool(
           presolve, "parallelcols.enabled", 1 );
-      REQUIRE( result == 1 );
+      REQUIRE( result == LIBPAPILO_PARAM_OK );
 
       libpapilo_postsolve_storage_t* postsolve = nullptr;
       libpapilo_statistics_t* statistics = nullptr;
@@ -269,9 +271,9 @@ TEST_CASE( "disabling parallelcols prevents parallel column detection",
 
       // Disable ALL presolvers including parallelcols
       disableAllPresolversExcept( presolve, "" ); // empty = disable all
-      int result = libpapilo_presolve_set_param_bool(
+      libpapilo_param_result_t result = libpapilo_presolve_set_param_bool(
           presolve, "parallelcols.enabled", 0 );
-      REQUIRE( result == 1 );
+      REQUIRE( result == LIBPAPILO_PARAM_OK );
 
       libpapilo_postsolve_storage_t* postsolve = nullptr;
       libpapilo_statistics_t* statistics = nullptr;

--- a/test/libpapilo/ParameterTest.cpp
+++ b/test/libpapilo/ParameterTest.cpp
@@ -79,8 +79,8 @@ TEST_CASE( "set-param-double-sets-double-parameter", "[parameter]" )
    libpapilo_presolve_add_default_presolvers( presolve );
 
    // Set numerics.feastol parameter
-   libpapilo_param_result_t result =
-       libpapilo_presolve_set_param_double( presolve, "numerics.feastol", 1e-6 );
+   libpapilo_param_result_t result = libpapilo_presolve_set_param_double(
+       presolve, "numerics.feastol", 1e-6 );
    REQUIRE( result == LIBPAPILO_PARAM_OK );
 
    // Unknown key should return NOT_FOUND
@@ -218,15 +218,15 @@ disableAllPresolversExcept( libpapilo_presolve_t* presolve,
 {
    // Disable all default presolvers (including cliquemerging)
    const char* presolvers[] = {
-       "cliquemerging.enabled",   "coefftightening.enabled",
-       "colsingleton.enabled",    "domcol.enabled",
-       "doubletoneq.enabled",     "dualfix.enabled",
-       "dualinfer.enabled",       "fixcontinuous.enabled",
-       "implint.enabled",         "parallelcols.enabled",
-       "parallelrows.enabled",    "probing.enabled",
-       "propagation.enabled",     "simpleprobing.enabled",
-       "simplifyineq.enabled",    "sparsify.enabled",
-       "stuffing.enabled",        "substitution.enabled" };
+       "cliquemerging.enabled", "coefftightening.enabled",
+       "colsingleton.enabled",  "domcol.enabled",
+       "doubletoneq.enabled",   "dualfix.enabled",
+       "dualinfer.enabled",     "fixcontinuous.enabled",
+       "implint.enabled",       "parallelcols.enabled",
+       "parallelrows.enabled",  "probing.enabled",
+       "propagation.enabled",   "simpleprobing.enabled",
+       "simplifyineq.enabled",  "sparsify.enabled",
+       "stuffing.enabled",      "substitution.enabled" };
 
    for( const char* p : presolvers )
    {

--- a/test/libpapilo/ParameterTest.cpp
+++ b/test/libpapilo/ParameterTest.cpp
@@ -23,7 +23,7 @@
 #include "papilo/external/catch/catch_amalgamated.hpp"
 #include <cstring>
 
-TEST_CASE( "set_param_bool disables presolver", "[parameter]" )
+TEST_CASE( "set-param-bool-disables-presolver", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
@@ -43,7 +43,7 @@ TEST_CASE( "set_param_bool disables presolver", "[parameter]" )
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "set_param_bool returns NOT_FOUND for unknown key", "[parameter]" )
+TEST_CASE( "set-param-bool-returns-not-found-for-unknown-key", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
@@ -57,7 +57,7 @@ TEST_CASE( "set_param_bool returns NOT_FOUND for unknown key", "[parameter]" )
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "set_param_int sets integer parameter", "[parameter]" )
+TEST_CASE( "set-param-int-sets-integer-parameter", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
@@ -72,7 +72,7 @@ TEST_CASE( "set_param_int sets integer parameter", "[parameter]" )
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "parse_param parses string value", "[parameter]" )
+TEST_CASE( "parse-param-parses-string-value", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
@@ -92,7 +92,7 @@ TEST_CASE( "parse_param parses string value", "[parameter]" )
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "parse_param returns NOT_FOUND for parse error", "[parameter]" )
+TEST_CASE( "parse-param-returns-not-found-for-parse-error", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
    libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
@@ -108,7 +108,7 @@ TEST_CASE( "parse_param returns NOT_FOUND for parse error", "[parameter]" )
    libpapilo_message_free( message );
 }
 
-TEST_CASE( "set_param_bool returns NOT_FOUND before presolvers are added",
+TEST_CASE( "set-param-bool-returns-not-found-before-presolvers-added",
            "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
@@ -217,7 +217,7 @@ disableAllPresolversExcept( libpapilo_presolve_t* presolve,
    }
 }
 
-TEST_CASE( "disabling parallelcols prevents parallel column detection",
+TEST_CASE( "disabling-parallelcols-prevents-parallel-column-detection",
            "[parameter][behavior]" )
 {
    // Test 1: With ONLY parallelcols enabled, parallel columns should be

--- a/test/libpapilo/ParameterTest.cpp
+++ b/test/libpapilo/ParameterTest.cpp
@@ -72,6 +72,26 @@ TEST_CASE( "set-param-int-sets-integer-parameter", "[parameter]" )
    libpapilo_message_free( message );
 }
 
+TEST_CASE( "set-param-double-sets-double-parameter", "[parameter]" )
+{
+   libpapilo_message_t* message = libpapilo_message_create();
+   libpapilo_presolve_t* presolve = libpapilo_presolve_create( message );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
+   // Set numerics.feastol parameter
+   libpapilo_param_result_t result =
+       libpapilo_presolve_set_param_double( presolve, "numerics.feastol", 1e-6 );
+   REQUIRE( result == LIBPAPILO_PARAM_OK );
+
+   // Unknown key should return NOT_FOUND
+   result =
+       libpapilo_presolve_set_param_double( presolve, "unknown.double", 1.0 );
+   REQUIRE( result == LIBPAPILO_PARAM_NOT_FOUND );
+
+   libpapilo_presolve_free( presolve );
+   libpapilo_message_free( message );
+}
+
 TEST_CASE( "parse-param-parses-string-value", "[parameter]" )
 {
    libpapilo_message_t* message = libpapilo_message_create();
@@ -196,23 +216,26 @@ static void
 disableAllPresolversExcept( libpapilo_presolve_t* presolve,
                             const char* keepEnabled )
 {
-   // Disable all common presolvers
+   // Disable all default presolvers (including cliquemerging)
    const char* presolvers[] = {
-       "coefftightening.enabled", "colsingleton.enabled",
-       "domcol.enabled",          "doubletoneq.enabled",
-       "dualfix.enabled",         "dualinfer.enabled",
-       "fixcontinuous.enabled",   "implint.enabled",
-       "parallelcols.enabled",    "parallelrows.enabled",
-       "probing.enabled",         "propagation.enabled",
-       "simpleprobing.enabled",   "simplifyineq.enabled",
-       "sparsify.enabled",        "stuffing.enabled",
-       "substitution.enabled" };
+       "cliquemerging.enabled",   "coefftightening.enabled",
+       "colsingleton.enabled",    "domcol.enabled",
+       "doubletoneq.enabled",     "dualfix.enabled",
+       "dualinfer.enabled",       "fixcontinuous.enabled",
+       "implint.enabled",         "parallelcols.enabled",
+       "parallelrows.enabled",    "probing.enabled",
+       "propagation.enabled",     "simpleprobing.enabled",
+       "simplifyineq.enabled",    "sparsify.enabled",
+       "stuffing.enabled",        "substitution.enabled" };
 
    for( const char* p : presolvers )
    {
       if( strcmp( p, keepEnabled ) != 0 )
       {
-         libpapilo_presolve_set_param_bool( presolve, p, 0 );
+         libpapilo_param_result_t result =
+             libpapilo_presolve_set_param_bool( presolve, p, 0 );
+         INFO( "Disabling presolver: " << p );
+         REQUIRE( result == LIBPAPILO_PARAM_OK );
       }
    }
 }

--- a/test/libpapilo/PresolverStatsTest.cpp
+++ b/test/libpapilo/PresolverStatsTest.cpp
@@ -74,22 +74,22 @@ TEST_CASE( "per-presolver-statistics-are-tracked-correctly",
    auto* problem = create_test_problem();
    REQUIRE( problem != nullptr );
 
-   // Create and configure presolve options
-   auto* options = libpapilo_presolve_options_create();
-   REQUIRE( options != nullptr );
-
    // Create message handler
    auto* message = libpapilo_message_create();
    REQUIRE( message != nullptr );
    libpapilo_message_set_verbosity_level( message, 0 ); // quiet
 
+   // Create and configure presolve
+   auto* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
    // Run presolve
-   libpapilo_reductions_t* reductions = nullptr;
    libpapilo_postsolve_storage_t* postsolve = nullptr;
    libpapilo_statistics_t* statistics = nullptr;
 
-   auto status = libpapilo_presolve_apply(
-       problem, options, message, &reductions, &postsolve, &statistics );
+   auto status = libpapilo_presolve_apply_full( presolve, problem, &postsolve,
+                                                &statistics );
 
    // Check that presolve ran successfully
    REQUIRE( status != LIBPAPILO_PRESOLVE_STATUS_INFEASIBLE );
@@ -171,9 +171,8 @@ TEST_CASE( "per-presolver-statistics-are-tracked-correctly",
 
    // Clean up
    libpapilo_problem_free( problem );
-   libpapilo_presolve_options_free( options );
+   libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
-   libpapilo_reductions_free( reductions );
    libpapilo_postsolve_storage_free( postsolve );
    libpapilo_statistics_free( statistics );
 }
@@ -185,22 +184,22 @@ TEST_CASE( "per-presolver-statistics-match-overall-statistics",
    auto* problem = create_test_problem();
    REQUIRE( problem != nullptr );
 
-   // Create and configure presolve options
-   auto* options = libpapilo_presolve_options_create();
-   REQUIRE( options != nullptr );
-
-   // Create message handler with higher verbosity to see what's happening
+   // Create message handler
    auto* message = libpapilo_message_create();
    REQUIRE( message != nullptr );
    libpapilo_message_set_verbosity_level( message, 0 ); // quiet for tests
 
+   // Create and configure presolve
+   auto* presolve = libpapilo_presolve_create( message );
+   REQUIRE( presolve != nullptr );
+   libpapilo_presolve_add_default_presolvers( presolve );
+
    // Run presolve
-   libpapilo_reductions_t* reductions = nullptr;
    libpapilo_postsolve_storage_t* postsolve = nullptr;
    libpapilo_statistics_t* statistics = nullptr;
 
-   auto status = libpapilo_presolve_apply(
-       problem, options, message, &reductions, &postsolve, &statistics );
+   auto status = libpapilo_presolve_apply_full( presolve, problem, &postsolve,
+                                                &statistics );
 
    // Check that presolve ran successfully
    REQUIRE( status != LIBPAPILO_PRESOLVE_STATUS_INFEASIBLE );
@@ -231,9 +230,8 @@ TEST_CASE( "per-presolver-statistics-match-overall-statistics",
 
    // Clean up
    libpapilo_problem_free( problem );
-   libpapilo_presolve_options_free( options );
+   libpapilo_presolve_free( presolve );
    libpapilo_message_free( message );
-   libpapilo_reductions_free( reductions );
    libpapilo_postsolve_storage_free( postsolve );
    libpapilo_statistics_free( statistics );
 }


### PR DESCRIPTION
## Summary

### New Feature: Parameter Setting API
- `libpapilo_presolve_set_param_bool` / `set_param_int` / `set_param_double` / `parse_param`
- `libpapilo_param_result_t` enum for proper error handling
  - `LIBPAPILO_PARAM_OK`, `NOT_FOUND`, `WRONG_TYPE`, `INVALID_VALUE`

### API Cleanup
- **Removed**: `libpapilo_presolve_apply` (convenience function → can be implemented at higher layers)
- **Removed**: `libpapilo_presolve_apply_simple` (replaced by `apply_full`)
- **Kept**: `libpapilo_presolve_apply_full` (main presolve entry point)
- **Kept**: `libpapilo_presolve_apply_reductions` (low-level API)

## Motivation

Enable fine-grained control over individual presolvers. This API allows enabling/disabling specific presolvers before running presolve.

## Example Usage

```c
libpapilo_presolve_t* presolve = libpapilo_presolve_create(message);
libpapilo_presolve_add_default_presolvers(presolve);

// Disable parallel column detection
libpapilo_param_result_t result = 
    libpapilo_presolve_set_param_bool(presolve, "parallelcols.enabled", 0);
if (result != LIBPAPILO_PARAM_OK) {
    // Handle error
}

// Run presolve with full output
libpapilo_postsolve_storage_t* postsolve = nullptr;
libpapilo_statistics_t* statistics = nullptr;
libpapilo_presolve_apply_full(presolve, problem, &postsolve, &statistics);

libpapilo_presolve_free(presolve);
```

## Test Plan

- [x] Parameter API tests (8 test cases)
  - `set_param_bool`, `set_param_int`, `set_param_double`, `parse_param`
  - Error cases (unknown key, parse error, before presolvers added)
- [x] Behavioral test: verify `parallelcols.enabled=0` actually prevents ParallelCol detection

## Breaking Changes

- `libpapilo_presolve_apply` removed
- `libpapilo_presolve_apply_simple` removed

Migrate to `libpapilo_presolve_apply_full` if using these functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)